### PR TITLE
Add missing mxnet in text-preprocessing.ipynb

### DIFF
--- a/chapter_recurrent-neural-networks/text-preprocessing.ipynb
+++ b/chapter_recurrent-neural-networks/text-preprocessing.ipynb
@@ -15,7 +15,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install git+https://github.com/d2l-ai/d2l-en # installing d2l\n"
+    "!pip install git+https://github.com/d2l-ai/d2l-en # installing d2l\n",
+    "!pip install -U mxnet-cu101mkl==1.6.0  # updating mxnet to at least v1.6"
    ]
   },
   {


### PR DESCRIPTION
Without using pip install mxnet the first real code block in the notebook throws the error "No module named 'mxnet'".

See full error in issue #3 .